### PR TITLE
Fix bug where ephemeral logs were not getting cleared

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ if (Meteor.isServer) {
 
 * `Queue.logLife`, default `30`. Days to keep logfiles.
 
-* `Queue.ephemeralLogLife`, default `1800000`. microseconds to keep ephemeral log statuses
+* `Queue.ephemeralLogLife`, default `1800000`. milliseconds to keep ephemeral log statuses
 
 * `Queue.ephemeralLogStatuses`, default `['lockfailed','success']`. statuses to purge from logs quickly;
 

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -1,11 +1,12 @@
 Queue.purgeOldLogs = function () {
-    var ephemeral = before = new Date();
+    var before = new Date();
     before.setDate(before.getDate() - Queue.logLife);
     Queue.log.remove({created_at: {$lte: before}});
 
     /* remove more ephemeral statuses */
-    ephemeral.setDate(ephemeral.getTime() - Queue.ephemeralLogLife )
-    Queue.log.remove({created_at: {$lte: before},  status: {$in: Queue.ephemeralLogStatuses}});
+    var ephemeral = new Date();
+    ephemeral.setTime(ephemeral.getTime() - Queue.ephemeralLogLife )
+    Queue.log.remove({created_at: {$lte: ephemeral},  status: {$in: Queue.ephemeralLogStatuses}});
 
 };
 

--- a/package.js
+++ b/package.js
@@ -1,4 +1,5 @@
 Package.describe({
+    name: "artwells:queue",
     summary: "job queue for meteor, using mongo and setInterval",
     version: "0.1.1",
     git: "https://github.com/artwells/meteor-queue.git"
@@ -7,6 +8,7 @@ Package.describe({
 Package.on_use(function (api) {
     api.versionsFrom("METEOR@1.0.3");
     api.use('mongo',['server']);
+    api.use('underscore',['server']);
     api.use('matb33:collection-hooks@0.7.3',['server']);
     api.use(['templating'], 'client');
     api.use('houston:admin@2.0.2',['server','client'],{weak:true});
@@ -20,6 +22,7 @@ Package.on_use(function (api) {
 Package.on_test(function (api) {
     api.versionsFrom("METEOR@1.0.3");
     api.use('mongo',['server']);
+    api.use('underscore',['server']);
     api.use('matb33:collection-hooks',['server']);
     api.use('artwells:queue', 'server');
     api.use('tinytest', 'server');

--- a/queue.js
+++ b/queue.js
@@ -6,7 +6,7 @@ if (typeof Queue.logLife === "undefined") {
     Queue.logLife = 30; /* days to keep logfiles */
 }
 if (typeof Queue.ephemeralLogLife === "undefined") {
-    Queue.ephemeralLogLife = 1800000; /* microseconds to keep ephemeral log statuses */
+    Queue.ephemeralLogLife = 1800000; /* milliseconds to keep ephemeral log statuses */
 }
 if (typeof Queue.ephemeralLogStatuses === "undefined") {
     Queue.ephemeralLogStatuses = ['lockfailed','success']; /* statuses to purge from logs quickly */

--- a/tests/server.js
+++ b/tests/server.js
@@ -10,7 +10,7 @@ Tinytest.add(
     function (test) {
         var savedLogLife = Queue.logLife;
         var savedEphemeralLogStatuses = Queue.ephemeralLogStatuses;
-        var ebefore = before = new Date();
+        var before = new Date();
         before.setDate(before.getDate() - 3000);
         Queue.log.insert({command: 'OLDTEST', status: 'testlog', created_at: before});
         Queue.logLife = 3000; /*assuming no one will need 3000 days of logs */
@@ -21,8 +21,9 @@ Tinytest.add(
         res = Queue.log.findOne({command: 'OLDTEST'});
         test.isUndefined(res, 'old log purge failed');
 
-        ebefore.setDate(ebefore.getTime() - Queue.ephemeralLogLife);
-        Queue.ephemeralLogStatuses = ['ephtest '];
+        var ebefore = new Date();
+        ebefore.setTime(ebefore.getTime() - Queue.ephemeralLogLife);
+        Queue.ephemeralLogStatuses = ['ephtest'];
         Queue.log.insert({command: 'OLDEPHEMERAL', status: 'ephtest', created_at: ebefore});
         var eres = Queue.log.findOne({command: 'OLDEPHEMERAL'});
         test.equal(eres.command, 'OLDEPHEMERAL', 'ephemeral log missing');


### PR DESCRIPTION
Hello, thanks for the package. Great work. So much easier to drop in a database queue if possible rather than setup a whole other service just to queue jobs.

I had a problem where the ephemeral logs were not getting cleared in my database. Over time, it generated over 1MM records in the log. I noticed a number of issues with both the code designed to purge ephemeral logs and in the test for the same. I think, due to some interactions and by sheer coincidence, the test passed in spite of these issues. In creating this PR, I got the tests broken, then got them passing again with these changes. 

Details are in the commit message. What do you think?  Possible to release these soon?