### PR TITLE
Fix function name in example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ if (Meteor.isServer) {
     /* set maintenance tasks */
     Queue.setInterval('purgeLocks', 'Queue.purgeOldLocks', 60000); /* once a minute */
     Queue.setInterval('purgeCompleted', 'Queue.purgeCompletedTasks()', 86400000); /* once a day */
-    Queue.setInterval('purgeLogs','Queue.purgeLogs()', 86400000); /* once a day */
+    Queue.setInterval('purgeLogs','Queue.purgeOldLogs()', 86400000); /* once a day */
 
 }
 ```


### PR DESCRIPTION
Changed this function name in the example code to match the _actual_ function name in the library. I had copied/pasted this code (silly me), so lost some time over this.